### PR TITLE
STDC format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,7 +369,8 @@ endforeach()
 
 add_subdirectory(src/firmware/${OS})
 
-add_subdirectory(src/lib/DriverFramework/framework/src)
+# TODO: add back once we use them
+# add_subdirectory(src/lib/DriverFramework/framework/src)
 
 #add_dependencies(df_driver_framework nuttx_export_${CONFIG}.stamp)
 if (NOT "${OS}" STREQUAL "nuttx")

--- a/Tools/generate_listener.py
+++ b/Tools/generate_listener.py
@@ -114,7 +114,6 @@ print("""
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #ifndef PRIu64

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -671,6 +671,7 @@ function(px4_add_common_flags)
 	string(REPLACE "-" "_" board_config ${board_upper})
 	set(added_definitions
 		-DCONFIG_ARCH_BOARD_${board_config}
+		-D__STDC_FORMAT_MACROS
 		)
 
 	if (NOT ${CMAKE_C_COMPILER_ID} MATCHES ".*Clang.*")

--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -41,7 +41,6 @@
 
 #include <sys/types.h>
 #include <stdbool.h>
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #include <px4_time.h>

--- a/src/drivers/px4flow/i2c_frame.h
+++ b/src/drivers/px4flow/i2c_frame.h
@@ -41,7 +41,6 @@
 #ifndef I2C_FRAME_H_
 #define I2C_FRAME_H_
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 typedef  struct i2c_frame {

--- a/src/firmware/nuttx/CMakeLists.txt
+++ b/src/firmware/nuttx/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(firmware_nuttx
 set(nuttx_export_dir ${CMAKE_BINARY_DIR}/${BOARD}/NuttX/nuttx-export)
 
 set(link_libs
-	romfs apps nuttx m gcc df_driver_framework
+	romfs apps nuttx m gcc
 	)
 
 if(NOT ${BOARD} STREQUAL "sim")

--- a/src/modules/controllib/block/Block.hpp
+++ b/src/modules/controllib/block/Block.hpp
@@ -39,7 +39,6 @@
 
 #pragma once
 
-#define __STDC_FORMAT_MACROS
 #include <stdint.h>
 #include <inttypes.h>
 

--- a/src/modules/px4iofirmware/protocol.h
+++ b/src/modules/px4iofirmware/protocol.h
@@ -33,7 +33,6 @@
 
 #pragma once
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 /**

--- a/src/modules/systemlib/err.c
+++ b/src/modules/systemlib/err.c
@@ -40,7 +40,6 @@
 
 #include <px4_config.h>
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #include <stdlib.h>

--- a/src/modules/systemlib/uthash/uthash.h
+++ b/src/modules/systemlib/uthash/uthash.h
@@ -61,7 +61,6 @@ do {                                                                            
 typedef unsigned int uint32_t;
 typedef unsigned char uint8_t;
 #else
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>   /* uint32_t */
 #endif
 

--- a/src/platforms/posix/drivers/barosim/baro.cpp
+++ b/src/platforms/posix/drivers/barosim/baro.cpp
@@ -36,7 +36,6 @@
  * Driver for the simulated barometric pressure sensor
  */
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <px4_config.h>
 #include <px4_defines.h>

--- a/src/platforms/posix/drivers/gpssim/gpssim.cpp
+++ b/src/platforms/posix/drivers/gpssim/gpssim.cpp
@@ -37,7 +37,6 @@
  */
 
 #include <sys/types.h>
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdbool.h>

--- a/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
+++ b/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
@@ -41,7 +41,6 @@
  * @author Mark Charlebois
  */
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #include <px4_config.h>

--- a/src/platforms/posix/px4_layer/drv_hrt.c
+++ b/src/platforms/posix/px4_layer/drv_hrt.c
@@ -45,7 +45,6 @@
 #include <semaphore.h>
 #include <time.h>
 #include <string.h>
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <errno.h>
 #include "hrt_work.h"

--- a/src/platforms/px4_log.h
+++ b/src/platforms/px4_log.h
@@ -117,7 +117,6 @@ static inline void do_nothing(int level, ...)
 
 #else
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdint.h>
 #include <sys/cdefs.h>

--- a/src/platforms/px4_nodehandle.h
+++ b/src/platforms/px4_nodehandle.h
@@ -48,7 +48,6 @@
 /* includes when building for ros */
 #include "ros/ros.h"
 #include <list>
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <type_traits>
 #else

--- a/src/systemcmds/tests/test_bson.c
+++ b/src/systemcmds/tests/test_bson.c
@@ -37,7 +37,6 @@
  * Tests for the bson en/decoder
  */
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #include <px4_defines.h>

--- a/src/systemcmds/tests/test_int.c
+++ b/src/systemcmds/tests/test_int.c
@@ -36,7 +36,6 @@
  * Included Files
  ****************************************************************************/
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #include <px4_config.h>


### PR DESCRIPTION
Cherry-pick commit from upstream: https://github.com/PX4/Firmware/pull/5007

There we also update ecl and DriversFramework submodules. Here we just disable DriversFramework that should not be enabled nonetheless because it isn't present on the Make build.