### PR TITLE
px4iofirmware: cmake: use EXTRA_C{,XX}_FLAGS variables

### DIFF
--- a/src/modules/px4iofirmware/CMakeLists.txt
+++ b/src/modules/px4iofirmware/CMakeLists.txt
@@ -61,6 +61,9 @@ px4_join(OUT CMAKE_EXE_LINKER_FLAGS LIST "${exe_linker_flags}" GLUE " ")
 px4_join(OUT CMAKE_C_FLAGS LIST "${c_flags}" GLUE " ")
 px4_join(OUT CMAKE_CXX_FLAGS LIST "${cxx_flags}" GLUE " ")
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_CXX_FLAGS}")
+
 include_directories(
 	${include_dirs}
 	${CMAKE_BINARY_DIR}/src/modules/systemlib/mixer


### PR DESCRIPTION
This CMakeLists.txt overwrites the CMAKE_C{,XX}_FLAGS variable, so we need to
get the extra flags.