### PR TITLE
added SRXL decoder and fixed DSM decoder on FMUv4 for 14 channels

### DIFF
--- a/msg/input_rc.msg
+++ b/msg/input_rc.msg
@@ -12,6 +12,8 @@ uint8 RC_INPUT_SOURCE_PX4FMU_ST24 = 10
 uint8 RC_INPUT_SOURCE_PX4FMU_SUMD = 11
 uint8 RC_INPUT_SOURCE_PX4FMU_DSM = 12
 uint8 RC_INPUT_SOURCE_PX4IO_SUMD = 13
+uint8 RC_INPUT_SOURCE_PX4FMU_SRXL = 14
+uint8 RC_INPUT_SOURCE_PX4IO_SRXL = 15
 
 uint8 RC_INPUT_MAX_CHANNELS = 18 	# Maximum number of R/C input channels in the system. S.Bus has up to 18 channels.
 

--- a/src/drivers/px4fmu/module.mk
+++ b/src/drivers/px4fmu/module.mk
@@ -8,6 +8,7 @@ SRCS		 = fmu.cpp \
 		  ../../lib/rc/dsm.c \
 		  ../../lib/rc/st24.c \
 		  ../../lib/rc/sumd.c \
+		  ../../lib/rc/srxl.c \
 		   px4fmu_params.c
 
 MODULE_STACKSIZE = 1200

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1854,6 +1854,9 @@ PX4IO::io_publish_raw_rc()
 	} else if (_status & PX4IO_P_STATUS_FLAGS_RC_ST24) {
 		rc_val.input_source = input_rc_s::RC_INPUT_SOURCE_PX4IO_ST24;
 
+	} else if (_status & PX4IO_P_STATUS_FLAGS_RC_SRXL) {
+		rc_val.input_source = input_rc_s::RC_INPUT_SOURCE_PX4IO_SRXL;
+
 	} else {
 		rc_val.input_source = input_rc_s::RC_INPUT_SOURCE_UNKNOWN;
 
@@ -2196,6 +2199,7 @@ PX4IO::print_status(bool extended_status)
 	       ((flags & PX4IO_P_STATUS_FLAGS_RC_DSM)   ? " DSM" : ""),
 	       ((flags & PX4IO_P_STATUS_FLAGS_RC_ST24)   ? " ST24" : ""),
 	       ((flags & PX4IO_P_STATUS_FLAGS_RC_SBUS)  ? " SBUS" : ""),
+	       ((flags & PX4IO_P_STATUS_FLAGS_RC_SRXL)  ? " SRXL" : ""),
 	       ((flags & PX4IO_P_STATUS_FLAGS_FMU_OK)   ? " FMU_OK" : " FMU_FAIL"),
 	       ((flags & PX4IO_P_STATUS_FLAGS_RAW_PWM)  ? " RAW_PWM_PASSTHROUGH" : ""),
 	       ((flags & PX4IO_P_STATUS_FLAGS_MIXER_OK) ? " MIXER_OK" : " MIXER_FAIL"),
@@ -2830,6 +2834,9 @@ PX4IO::ioctl(file *filep, int cmd, unsigned long arg)
 
 			} else if (status & PX4IO_P_STATUS_FLAGS_RC_ST24) {
 				rc_val->input_source = input_rc_s::RC_INPUT_SOURCE_PX4IO_ST24;
+
+			} else if (status & PX4IO_P_STATUS_FLAGS_RC_SRXL) {
+				rc_val->input_source = input_rc_s::RC_INPUT_SOURCE_PX4IO_SRXL;
 
 			} else {
 				rc_val->input_source = input_rc_s::RC_INPUT_SOURCE_UNKNOWN;

--- a/src/lib/rc/CMakeLists.txt
+++ b/src/lib/rc/CMakeLists.txt
@@ -39,6 +39,7 @@ px4_add_module(
 		sumd.c
 		sbus.c
 		dsm.c
+		srxl.c
 	DEPENDS
 		platforms__common
 	)

--- a/src/lib/rc/module.mk
+++ b/src/lib/rc/module.mk
@@ -37,6 +37,6 @@
 #
 
 SRCS		 =	st24.c \
-				sumd.c
+				sumd.c srxl.c
 
 MAXOPTIMIZATION	 = -Os

--- a/src/lib/rc/srxl.h
+++ b/src/lib/rc/srxl.h
@@ -1,0 +1,32 @@
+// -*- tab-width: 8; Mode: C++; c-basic-offset: 8; indent-tabs-mode: -*- t -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  SRXL protocol decoder
+  Andrew Tridgell, September 2016
+ */
+
+#pragma once
+
+__BEGIN_DECLS
+
+/*
+ * Decoder for SRXL protocol
+ *
+ * @return 0 for success (a decoded packet), 1 for no packet yet (accumulating), 2 for unknown packet, 4 for checksum error
+ */
+__EXPORT int srxl_decode(uint64_t timestamp_us, uint8_t byte, uint8_t *num_values, uint16_t *values, uint16_t max_values);
+
+__END_DECLS

--- a/src/modules/px4iofirmware/CMakeLists.txt
+++ b/src/modules/px4iofirmware/CMakeLists.txt
@@ -90,6 +90,7 @@ set(srcs
 	../../lib/rc/sumd.c
 	../../lib/rc/sbus.c
 	../../lib/rc/dsm.c
+	../../lib/rc/srxl.c
 	../../drivers/stm32/drv_hrt.c
 	../../drivers/stm32/drv_io_timer.c
 	../../drivers/stm32/drv_pwm_servo.c

--- a/src/modules/px4iofirmware/controls.c
+++ b/src/modules/px4iofirmware/controls.c
@@ -48,6 +48,7 @@
 #include <rc/sumd.h>
 #include <rc/sbus.h>
 #include <rc/dsm.h>
+#include <rc/srxl.h>
 
 #include "px4io.h"
 
@@ -56,7 +57,8 @@
 #define RC_CHANNEL_LOW_THRESH		-8000	/* 10% threshold */
 
 static bool	ppm_input(uint16_t *values, uint16_t *num_values, uint16_t *frame_len);
-static bool	dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool *sumd_updated);
+static bool	dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool *sumd_updated,
+			       bool *srxl_updated);
 
 static perf_counter_t c_gather_dsm;
 static perf_counter_t c_gather_sbus;
@@ -71,16 +73,22 @@ static uint16_t rc_value_override = 0;
 static unsigned _rssi_adc_counts = 0;
 #endif
 
-bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool *sumd_updated)
+bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool *sumd_updated, bool *srxl_updated)
 {
 	perf_begin(c_gather_dsm);
 	uint8_t n_bytes = 0;
 	uint8_t *bytes;
 	bool dsm_11_bit;
-	*dsm_updated = dsm_input(_dsm_fd, r_raw_rc_values, &r_raw_rc_count, &dsm_11_bit, &n_bytes, &bytes,
-				 PX4IO_RC_INPUT_CHANNELS);
+	uint16_t dsm_chan_count;
 
-	if (*dsm_updated) {
+	// we don't accept DSM if we are currently decoding SRXL, as
+	// SRXL can be incorrectly interpreted as DSM
+	bool allow_dsm = !(r_status_flags & PX4IO_P_STATUS_FLAGS_RC_SRXL);
+
+	*dsm_updated = dsm_input(_dsm_fd, r_raw_rc_values, &dsm_chan_count, &dsm_11_bit, &n_bytes, &bytes,
+				 allow_dsm ? PX4IO_RC_INPUT_CHANNELS : 0);
+
+	if (*dsm_updated && dsm_chan_count > 0) {
 
 		if (dsm_11_bit) {
 			r_raw_rc_flags |= PX4IO_P_RAW_RC_FLAGS_RC_DSM11;
@@ -92,6 +100,7 @@ bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool 
 		r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_FRAME_DROP);
 		r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_FAILSAFE);
 
+		r_raw_rc_count = dsm_chan_count;
 	}
 
 	perf_end(c_gather_dsm);
@@ -146,7 +155,29 @@ bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool 
 		r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_FAILSAFE);
 	}
 
-	return (*dsm_updated | *st24_updated | *sumd_updated);
+	/* attempt to parse with SRXL lib */
+	uint8_t srxl_channel_count = 0;
+	hrt_abstime now = hrt_absolute_time();
+
+	*srxl_updated = false;
+
+	for (unsigned i = 0; i < n_bytes; i++) {
+		/* set updated flag if one complete packet was parsed */
+		*srxl_updated |= (OK == srxl_decode(now, bytes[i],
+						    &srxl_channel_count, r_raw_rc_values, PX4IO_RC_INPUT_CHANNELS));
+	}
+
+	if (*srxl_updated) {
+
+		/* not setting RSSI since SRXL does not provide one */
+		r_raw_rc_count = srxl_channel_count;
+
+		r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_SRXL;
+		r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_FRAME_DROP);
+		r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_FAILSAFE);
+	}
+
+	return (*dsm_updated | *st24_updated | *sumd_updated | *srxl_updated);
 }
 
 void
@@ -223,8 +254,8 @@ controls_tick()
 	}
 
 	perf_begin(c_gather_dsm);
-	bool dsm_updated, st24_updated, sumd_updated;
-	(void)dsm_port_input(&rssi, &dsm_updated, &st24_updated, &sumd_updated);
+	bool dsm_updated, st24_updated, sumd_updated, srxl_updated;
+	(void)dsm_port_input(&rssi, &dsm_updated, &st24_updated, &sumd_updated, &srxl_updated);
 
 	if (dsm_updated) {
 		r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_DSM;
@@ -236,6 +267,10 @@ controls_tick()
 
 	if (sumd_updated) {
 		r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_SUMD;
+	}
+
+	if (srxl_updated) {
+		r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_SRXL;
 	}
 
 	perf_end(c_gather_dsm);
@@ -309,7 +344,7 @@ controls_tick()
 	/*
 	 * If we received a new frame from any of the RC sources, process it.
 	 */
-	if (dsm_updated || sbus_updated || ppm_updated || st24_updated || sumd_updated) {
+	if (dsm_updated || sbus_updated || ppm_updated || st24_updated || sumd_updated || srxl_updated) {
 
 		/* record a bitmask of channels assigned */
 		unsigned assigned_channels = 0;
@@ -446,6 +481,9 @@ controls_tick()
 		r_status_flags &= ~(
 					  PX4IO_P_STATUS_FLAGS_RC_PPM |
 					  PX4IO_P_STATUS_FLAGS_RC_DSM |
+					  PX4IO_P_STATUS_FLAGS_RC_ST24 |
+					  PX4IO_P_STATUS_FLAGS_RC_SUMD |
+					  PX4IO_P_STATUS_FLAGS_RC_SRXL |
 					  PX4IO_P_STATUS_FLAGS_RC_SBUS);
 
 	}

--- a/src/modules/px4iofirmware/module.mk
+++ b/src/modules/px4iofirmware/module.mk
@@ -14,7 +14,8 @@ SRCS		= adc.c \
 		  ../systemlib/mixer/mixer_simple.cpp \
 		  ../systemlib/pwm_limit/pwm_limit.c \
 		  ../../lib/rc/st24.c \
-		  ../../lib/rc/sumd.c
+		  ../../lib/rc/sumd.c \
+		  ../../lib/rc/srxl.c
 
 ifeq ($(BOARD),px4io-v1)
 SRCS		+= i2c.c

--- a/src/modules/px4iofirmware/protocol.h
+++ b/src/modules/px4iofirmware/protocol.h
@@ -116,6 +116,7 @@
 #define PX4IO_P_STATUS_FLAGS_FMU_INITIALIZED	(1 << 13) /* FMU was initialized and OK once */
 #define PX4IO_P_STATUS_FLAGS_RC_ST24		(1 << 14) /* ST24 input is valid */
 #define PX4IO_P_STATUS_FLAGS_RC_SUMD		(1 << 15) /* SUMD input is valid */
+#define PX4IO_P_STATUS_FLAGS_RC_SRXL		(1 << 15) /* SRXL input is valid - reuses SUMD bit as we're out of bits */
 
 #define PX4IO_P_STATUS_ALARMS			3	 /* alarm flags - alarms latch, write 1 to a bit to clear it */
 #define PX4IO_P_STATUS_ALARMS_VBATT_LOW		(1 << 0) /* [1] VBatt is very close to regulator dropout */

--- a/src/modules/px4iofirmware/px4io.c
+++ b/src/modules/px4iofirmware/px4io.c
@@ -238,6 +238,7 @@ control_IMU_heater(uint16_t duty_cycle)
 {
 	if (duty_cycle == 0) {
 		LED_BLUE(false);
+
 	} else {
 		uint8_t cycle = ((hrt_absolute_time() / 10000UL) % 100U);
 		LED_BLUE(!(cycle >= duty_cycle));
@@ -256,11 +257,11 @@ control_heartbeat_LED(void)
 {
 	uint32_t heartbeat_period_us = 250 * 1000UL;
 	static uint64_t last_heartbeat_time = 0;
-	
+
 	if (r_status_flags & PX4IO_P_STATUS_FLAGS_OVERRIDE) {
 		heartbeat_period_us /= 4;
 	}
-	
+
 	if ((hrt_absolute_time() - last_heartbeat_time) > heartbeat_period_us) {
 		last_heartbeat_time = hrt_absolute_time();
 		heartbeat_blink();
@@ -431,6 +432,7 @@ user_start(int argc, char *argv[])
 
 		if (r_page_setup[PX4IO_P_SETUP_HEATER_DUTY_CYCLE] <= PX4IO_HEATER_MAX) {
 			control_IMU_heater(r_page_setup[PX4IO_P_SETUP_HEATER_DUTY_CYCLE]);
+
 		} else {
 			control_heartbeat_LED();
 		}


### PR DESCRIPTION
This adds support for the SRXL protocol used in new spektrum receivers, and fixes a number of bugs in the DSM decoder when used in px4fmu for FMUv4
