### PR TITLE
px4io: stop breathing on LED4; causes magnetic interference

### DIFF
--- a/src/modules/px4iofirmware/px4io.c
+++ b/src/modules/px4iofirmware/px4io.c
@@ -133,6 +133,9 @@ heartbeat_blink(void)
 	LED_BLUE(heartbeat = !heartbeat);
 }
 
+// breathing on proficnc's "The Cube" causes magnetic interference.
+#define BREATHE 0
+
 static void
 ring_blink(void)
 {
@@ -144,6 +147,7 @@ ring_blink(void)
 		return;
 	}
 
+#if BREATH
 	// XXX this led code does have
 	// intentionally a few magic numbers.
 	const unsigned max_brightness = 118;
@@ -188,7 +192,9 @@ ring_blink(void)
 		on_counter = 0;
 		counter++;
 	}
-
+#else
+    LED_RING(0);
+#endif
 #endif
 }
 


### PR DESCRIPTION
[12:03:20 PM] Peter Barker: You mentioned you'd like to get rid of the breathing lights on The Cube.  I've got patches that dim the vehicle when the vehicle is safe rather than breathing: https://github.com/peterbarker/PX4Firmware/tree/led4-no-breathe
[12:03:26 PM] Peter Barker: Is that the sort of thing you wanted?
[12:04:01 PM] Peter Barker: Just turning them off means the cube would look dead (or at lteast mine would!)
[12:04:36 PM] Philip Rowse: Dim would still pulse it, the pulsing is affecting the IMU.

Full on or full off is ok
[12:05:06 PM] Philip Rowse: I hope I have fixed the problem in hardware...
[12:05:21 PM] Philip Rowse: But won't know till the new ones show up
[12:05:45 PM] Philip Rowse: I removed the LEDs near the sensors
[12:06:02 PM] Philip Rowse: And all traces to do with them
[12:06:04 PM] Peter Barker: OK.  So we should delay this sort of patch until you know you've still got the issue?
[12:06:43 PM] Philip Rowse: Be best we turned them off by default to start with...
[12:07:06 PM] Philip Rowse: We can then get fancy later, if it's all ok
[12:07:38 PM] Philip Rowse: Or a param... On vs off vs dim...

Then we can do some real testing
[12:08:26 PM] Peter Barker: :-)  Hard to do via a parameter since the code that does the throbbing is down in PX4Firmware's px4io layer.  If I can find precedent we can do it.
[12:09:00 PM] Philip Rowse: Cool :) off is my preference in the short term
[12:12:41 PM] Peter Barker: OK.  Mind if I drop this conversation into the PR?
[12:16:32 PM] Philip Rowse: No problem :)
