### PR TITLE
Ap sumd grxx compatibility

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1245,6 +1245,7 @@ PX4FMU::cycle()
 	uint16_t raw_rc_count;
 	unsigned frame_drops;
 	bool dsm_11_bit;
+	bool failsafe_state;
 
 
 	if (_report_lock && _rc_scan_locked) {
@@ -1346,14 +1347,14 @@ PX4FMU::cycle()
 					/* set updated flag if one complete packet was parsed */
 					sumd_rssi = RC_INPUT_RSSI_MAX;
 					rc_updated = (OK == sumd_decode(_rcs_buf[i], &sumd_rssi, &rx_count,
-									&raw_rc_count, raw_rc_values, input_rc_s::RC_INPUT_MAX_CHANNELS));
+									&raw_rc_count, raw_rc_values, input_rc_s::RC_INPUT_MAX_CHANNELS, &failsafe_state));
 				}
 
 				if (rc_updated) {
 					// we have a new SUMD frame. Publish it.
 					_rc_in.input_source = input_rc_s::RC_INPUT_SOURCE_PX4FMU_SUMD;
 					fill_rc_in(raw_rc_count, raw_rc_values, _cycle_timestamp,
-						   false, false, frame_drops, sumd_rssi);
+						   false, failsafe_state, frame_drops, sumd_rssi);
 					_rc_scan_locked = true;
 				}
 			}
@@ -1380,7 +1381,6 @@ PX4FMU::cycle()
 				// parse new data
 				rc_updated = false;
                                 uint8_t srxl_chan_count;
-				bool failsafe_state;
                                 
 				for (unsigned i = 0; i < (unsigned)newBytes; i++) {
 					/* set updated flag if one complete packet was parsed */

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1854,6 +1854,9 @@ PX4IO::io_publish_raw_rc()
 	} else if (_status & PX4IO_P_STATUS_FLAGS_RC_ST24) {
 		rc_val.input_source = input_rc_s::RC_INPUT_SOURCE_PX4IO_ST24;
 
+	} else if (_status & PX4IO_P_STATUS_FLAGS_RC_SUMD) {
+		rc_val.input_source = input_rc_s::RC_INPUT_SOURCE_PX4IO_SUMD;
+
 	} else if (_status & PX4IO_P_STATUS_FLAGS_RC_SRXL) {
 		rc_val.input_source = input_rc_s::RC_INPUT_SOURCE_PX4IO_SRXL;
 
@@ -2835,6 +2838,9 @@ PX4IO::ioctl(file *filep, int cmd, unsigned long arg)
 
 			} else if (status & PX4IO_P_STATUS_FLAGS_RC_ST24) {
 				rc_val->input_source = input_rc_s::RC_INPUT_SOURCE_PX4IO_ST24;
+
+			} else if (status & PX4IO_P_STATUS_FLAGS_RC_SUMD) {
+				rc_val->input_source = input_rc_s::RC_INPUT_SOURCE_PX4IO_SUMD;
 
 			} else if (status & PX4IO_P_STATUS_FLAGS_RC_SRXL) {
 				rc_val->input_source = input_rc_s::RC_INPUT_SOURCE_PX4IO_SRXL;

--- a/src/lib/rc/dsm.c
+++ b/src/lib/rc/dsm.c
@@ -572,6 +572,9 @@ dsm_input(int fd, uint16_t *values, uint16_t *num_values, bool *dsm_11_bit, uint
 	} else {
 		*n_bytes = ret;
 		*bytes = &dsm_buf[0];
+
+		/* return immediately if dsm parsing is deactivated*/
+		if (max_values == 0 ) return false;
 	}
 
 	/*

--- a/src/lib/rc/sumd.c
+++ b/src/lib/rc/sumd.c
@@ -55,35 +55,12 @@ enum SUMD_DECODE_STATE {
 	SUMD_DECODE_STATE_GOT_CRC16_BYTE_2
 };
 
-/*
-const char *decode_states[] = {"UNSYNCED",
-			       "GOT_HEADER",
-			       "GOT_STATE",
-			       "GOT_LEN",
-			       "GOT_DATA",
-			       "GOT_CRC",
-			       "GOT_CRC16_BYTE_1",
-			       "GOT_CRC16_BYTE_2"
-			      };
-*/
-
 uint8_t 	_crc8 	= 0x00;
 uint16_t 	_crc16 = 0x0000;
 bool 		_sumd 		= true;
 bool		_crcOK		= false;
 bool		_debug		= false;
 
-
-/* define range mapping here, -+100% -> 1000..2000 */
-#define SUMD_RANGE_MIN 0.0f
-#define SUMD_RANGE_MAX 4096.0f
-
-#define SUMD_TARGET_MIN 1000.0f
-#define SUMD_TARGET_MAX 2000.0f
-
-/* pre-calculate the floating point stuff as far as possible at compile time */
-#define SUMD_SCALE_FACTOR ((SUMD_TARGET_MAX - SUMD_TARGET_MIN) / (SUMD_RANGE_MAX - SUMD_RANGE_MIN))
-#define SUMD_SCALE_OFFSET (int)(SUMD_TARGET_MIN - (SUMD_SCALE_FACTOR * SUMD_RANGE_MIN + 0.5f))
 
 static enum SUMD_DECODE_STATE _decode_state = SUMD_DECODE_STATE_UNSYNCED;
 static uint8_t _rxlen;
@@ -200,7 +177,6 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 				printf(" SUMD_DECODE_STATE_GOT_LEN: %x (%d) \n", byte, byte) ;
 			}
 
-
 		} else if (byte == SUMD_HEADER_ID) {
 			/* first header byte was a spurious one found in the checksum of the last frame */
 			/*=> restart frame decoding */
@@ -229,7 +205,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 
 		_rxlen++;
 
-		if (_rxlen < ((_rxpacket.length * 2))) {
+		if (_rxlen < (_rxpacket.length * 2)) {
 			if (_debug) {
 				printf(" SUMD_DECODE_STATE_GOT_DATA[%d]: %x\n", _rxlen, byte) ;
 			}
@@ -342,7 +318,6 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 			if ((uint16_t)_rxpacket.length > max_chan_count) {
 				_rxpacket.length = (uint8_t) max_chan_count;
 			}
-
 			*channel_count = (uint16_t)_rxpacket.length;
 
 			/* decode the actual packet */
@@ -368,8 +343,6 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 				}
 
 				channels[chan_index] = (uint16_t)((_rxpacket.sumd_data[i * 2] << 8) | _rxpacket.sumd_data[i * 2 + 1]) >> 3;
-				/* convert values to 1000-2000 ppm encoding in a not too sloppy fashion */
-				//channels[chan_index] = (uint16_t)(channels[chan_index] * SUMD_SCALE_FACTOR + .5f) + SUMD_SCALE_OFFSET;
 
 				chan_index++;
 			}

--- a/src/lib/rc/sumd.c
+++ b/src/lib/rc/sumd.c
@@ -161,7 +161,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 		break;
 
 	case SUMD_DECODE_STATE_GOT_STATE:
-		if (byte >= 2 && byte <= SUMD_MAX_CHANNELS) {
+		if (byte >= 4 && byte <= SUMD_MAX_CHANNELS) {
 			_rxpacket.length = byte;
 
 			if (_sumd) {

--- a/src/lib/rc/sumd.c
+++ b/src/lib/rc/sumd.c
@@ -180,7 +180,6 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 				_crc8 = sumd_crc8(_crc8, byte);
 			}
 
-			_rxlen++;
 			_decode_state = SUMD_DECODE_STATE_GOT_LEN;
 
 			if (_debug) {
@@ -205,9 +204,9 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 
 		_rxlen++;
 
-		if (_rxlen <= ((_rxpacket.length * 2))) {
+		if (_rxlen < ((_rxpacket.length * 2))) {
 			if (_debug) {
-				printf(" SUMD_DECODE_STATE_GOT_DATA[%d]: %x\n", _rxlen - 2, byte) ;
+				printf(" SUMD_DECODE_STATE_GOT_DATA[%d]: %x\n", _rxlen, byte) ;
 			}
 
 		} else {
@@ -301,7 +300,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 			}
 
 			if (_debug) {
-				printf(" RXLEN: %d  [Chans: %d] \n\n", _rxlen - 1, (_rxlen - 1) / 2) ;
+				printf(" RXLEN: %d  [Chans: %d] \n\n", _rxlen, (_rxlen + 1) / 2) ;
 			}
 
 			ret = 0;
@@ -325,25 +324,25 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 			/* reorder first 4 channels */
 
 			/* ch1 = roll -> sumd = ch2 */
-			channels[0] = (uint16_t)((_rxpacket.sumd_data[1 * 2 + 1] << 8) | _rxpacket.sumd_data[1 * 2 + 2]) >> 3;
+			channels[0] = (uint16_t)((_rxpacket.sumd_data[1 * 2] << 8) | _rxpacket.sumd_data[1 * 2 + 1]) >> 3;
 			/* ch2 = pitch -> sumd = ch2 */
-			channels[1] = (uint16_t)((_rxpacket.sumd_data[2 * 2 + 1] << 8) | _rxpacket.sumd_data[2 * 2 + 2]) >> 3;
+			channels[1] = (uint16_t)((_rxpacket.sumd_data[2 * 2] << 8) | _rxpacket.sumd_data[2 * 2 + 1]) >> 3;
 			/* ch3 = throttle -> sumd = ch2 */
-			channels[2] = (uint16_t)((_rxpacket.sumd_data[0 * 2 + 1] << 8) | _rxpacket.sumd_data[0 * 2 + 2]) >> 3;
+			channels[2] = (uint16_t)((_rxpacket.sumd_data[0 * 2] << 8) | _rxpacket.sumd_data[0 * 2 + 1]) >> 3;
 			/* ch4 = yaw -> sumd = ch2 */
-			channels[3] = (uint16_t)((_rxpacket.sumd_data[3 * 2 + 1] << 8) | _rxpacket.sumd_data[3 * 2 + 2]) >> 3;
+			channels[3] = (uint16_t)((_rxpacket.sumd_data[3 * 2] << 8) | _rxpacket.sumd_data[3 * 2 + 1]) >> 3;
 
 			/* we start at channel 5(index 4) */
 			unsigned chan_index = 4;
 
 			for (i = 4; i < _rxpacket.length; i++) {
 				if (_debug) {
-					printf("ch[%d] : %x %x [ %x    %d ]\n", i + 1, _rxpacket.sumd_data[i * 2 + 1], _rxpacket.sumd_data[i * 2 + 2],
-					       ((_rxpacket.sumd_data[i * 2 + 1] << 8) | _rxpacket.sumd_data[i * 2 + 2]) >> 3,
-					       ((_rxpacket.sumd_data[i * 2 + 1] << 8) | _rxpacket.sumd_data[i * 2 + 2]) >> 3);
+					printf("ch[%d] : %x %x [ %x    %d ]\n", i + 1, _rxpacket.sumd_data[i * 2], _rxpacket.sumd_data[i * 2 + 1],
+					       ((_rxpacket.sumd_data[i * 2] << 8) | _rxpacket.sumd_data[i * 2 + 1]) >> 3,
+					       ((_rxpacket.sumd_data[i * 2] << 8) | _rxpacket.sumd_data[i * 2 + 1]) >> 3);
 				}
 
-				channels[chan_index] = (uint16_t)((_rxpacket.sumd_data[i * 2 + 1] << 8) | _rxpacket.sumd_data[i * 2 + 2]) >> 3;
+				channels[chan_index] = (uint16_t)((_rxpacket.sumd_data[i * 2] << 8) | _rxpacket.sumd_data[i * 2 + 1]) >> 3;
 				/* convert values to 1000-2000 ppm encoding in a not too sloppy fashion */
 				//channels[chan_index] = (uint16_t)(channels[chan_index] * SUMD_SCALE_FACTOR + .5f) + SUMD_SCALE_OFFSET;
 

--- a/src/lib/rc/sumd.c
+++ b/src/lib/rc/sumd.c
@@ -110,7 +110,7 @@ uint8_t sumd_crc8(uint8_t crc, uint8_t value)
 }
 
 int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channel_count, uint16_t *channels,
-		uint16_t max_chan_count)
+		uint16_t max_chan_count, bool *failsafe)
 {
 
 	int ret = 1;
@@ -143,7 +143,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 		break;
 
 	case SUMD_DECODE_STATE_GOT_HEADER:
-		if (byte == SUMD_ID_SUMD || byte == SUMD_ID_SUMH) {
+		if (byte == SUMD_ID_SUMD || byte == SUMD_ID_FAILSAFE || byte == SUMD_ID_SUMH) {
 			_rxpacket.status = byte;
 
 			if (byte == SUMD_ID_SUMH) {
@@ -310,6 +310,9 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 			*rx_count = _cnt;
 
 			*rssi = 100;
+
+			/* failsafe flag */
+			*failsafe= (_rxpacket.status == SUMD_ID_FAILSAFE);
 
 			/* received Channels */
 			if ((uint16_t)_rxpacket.length > max_chan_count) {

--- a/src/lib/rc/sumd.h
+++ b/src/lib/rc/sumd.h
@@ -88,6 +88,14 @@ uint16_t sumd_crc16(uint16_t crc, uint8_t value);
 uint8_t sumd_crc8(uint8_t crc, uint8_t value);
 
 /**
+ * start decoding implementation for SUMH protocol
+ *
+ * @param byte Received header
+ */
+void start_sumd_decode(uint8_t byte);
+
+
+/**
  * Decoder for SUMD/SUMH protocol
  *
  * @param byte current char to read
@@ -95,7 +103,7 @@ uint8_t sumd_crc8(uint8_t crc, uint8_t value);
  * @param rx_count pointer to a byte where the receive count of packets signce last wireless frame is written back to
  * @param channels pointer to a datastructure of size max_chan_count where channel values (12 bit) are written back to
  * @param max_chan_count maximum channels to decode - if more channels are decoded, the last n are skipped and success (0) is returned
- * @param failsafe pointer to a boolean where the decoded failsafe flag is written back to
+ * @param failsafe true if the decoded sumd frame has the failsafe flag set
  * @return 0 for success (a decoded packet), 1 for no packet yet (accumulating), 2 for unknown packet, 3 for out of sync, 4 for checksum error
  */
 /*

--- a/src/lib/rc/sumd.h
+++ b/src/lib/rc/sumd.h
@@ -95,14 +95,15 @@ uint8_t sumd_crc8(uint8_t crc, uint8_t value);
  * @param rx_count pointer to a byte where the receive count of packets signce last wireless frame is written back to
  * @param channels pointer to a datastructure of size max_chan_count where channel values (12 bit) are written back to
  * @param max_chan_count maximum channels to decode - if more channels are decoded, the last n are skipped and success (0) is returned
+ * @param failsafe pointer to a boolean where the decoded failsafe flag is written back to
  * @return 0 for success (a decoded packet), 1 for no packet yet (accumulating), 2 for unknown packet, 3 for out of sync, 4 for checksum error
  */
 /*
 __EXPORT int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channel_count,
-				 uint16_t *channels, uint16_t max_chan_count);
+				 uint16_t *channels, uint16_t max_chan_count, bool *failsafe);
 */
 __EXPORT int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channel_count,
-			 uint16_t *channels, uint16_t max_chan_count);
+			 uint16_t *channels, uint16_t max_chan_count, bool *failsafe);
 
 
 __END_DECLS

--- a/src/modules/px4iofirmware/controls.c
+++ b/src/modules/px4iofirmware/controls.c
@@ -81,9 +81,9 @@ bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool 
 	bool dsm_11_bit;
 	uint16_t dsm_chan_count;
 
-	// we don't accept DSM if we are currently decoding SRXL, as
-	// SRXL can be incorrectly interpreted as DSM
-	bool allow_dsm = !(r_status_flags & PX4IO_P_STATUS_FLAGS_RC_SRXL);
+	// we don't accept DSM if we are currently decoding ST24, SUMD, SRXL, as
+	// they can be incorrectly interpreted as DSM
+	bool allow_dsm = !(r_status_flags & (PX4IO_P_STATUS_FLAGS_RC_ST24 | PX4IO_P_STATUS_FLAGS_RC_SUMD | PX4IO_P_STATUS_FLAGS_RC_SRXL));
 
 	*dsm_updated = dsm_input(_dsm_fd, r_raw_rc_values, &dsm_chan_count, &dsm_11_bit, &n_bytes, &bytes,
 				 allow_dsm ? PX4IO_RC_INPUT_CHANNELS : 0);
@@ -290,8 +290,13 @@ controls_tick()
 	perf_begin(c_gather_sbus);
 
 	bool sbus_failsafe, sbus_frame_drop;
-	bool sbus_updated = sbus_input(_sbus_fd, r_raw_rc_values, &r_raw_rc_count, &sbus_failsafe, &sbus_frame_drop,
+	bool sbus_updated = false;
+
+	/* in case of dsm/st24/sumd/srxl input, sbus input (which is not protected with integrity checksum) is deactivated to avoid corruption */
+	if (!(r_status_flags & (PX4IO_P_STATUS_FLAGS_RC_DSM | PX4IO_P_STATUS_FLAGS_RC_ST24 | PX4IO_P_STATUS_FLAGS_RC_SUMD | PX4IO_P_STATUS_FLAGS_RC_SRXL))) {
+		sbus_updated = sbus_input(_sbus_fd, r_raw_rc_values, &r_raw_rc_count, &sbus_failsafe, &sbus_frame_drop,
 				       PX4IO_RC_INPUT_CHANNELS);
+	}
 
 	if (sbus_updated) {
 		r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_SBUS;
@@ -328,7 +333,12 @@ controls_tick()
 	 * disable the PPM decoder completely if we have S.bus signal.
 	 */
 	perf_begin(c_gather_ppm);
-	bool ppm_updated = ppm_input(r_raw_rc_values, &r_raw_rc_count, &r_page_raw_rc_input[PX4IO_P_RAW_RC_DATA]);
+	bool ppm_updated = false;
+
+	/* in case of dsm/st24/sumd/srxl/sbus input, ppm input (which is not protected with integrity checksum) is deactivated to avoid corruption */
+	if (!(r_status_flags & (PX4IO_P_STATUS_FLAGS_RC_DSM | PX4IO_P_STATUS_FLAGS_RC_ST24 | PX4IO_P_STATUS_FLAGS_RC_SUMD | PX4IO_P_STATUS_FLAGS_RC_SRXL | PX4IO_P_STATUS_FLAGS_RC_SBUS ))) {
+		ppm_updated = ppm_input(r_raw_rc_values, &r_raw_rc_count, &r_page_raw_rc_input[PX4IO_P_RAW_RC_DATA]);
+	}
 
 	if (ppm_updated) {
 

--- a/src/modules/px4iofirmware/controls.c
+++ b/src/modules/px4iofirmware/controls.c
@@ -135,7 +135,7 @@ bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool 
 	/* get data from FD and attempt to parse with SUMD libs */
 	uint8_t sumd_rssi, sumd_rx_count;
 	uint16_t sumd_channel_count = 0;
-        bool failsafe_state;
+        bool sumd_failsafe_state;
 
 	*sumd_updated = false;
 
@@ -143,7 +143,7 @@ bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool 
 		/* set updated flag if one complete packet was parsed */
 		sumd_rssi = RC_INPUT_RSSI_MAX;
 		*sumd_updated |= (OK == sumd_decode(bytes[i], &sumd_rssi, &sumd_rx_count,
-						    &sumd_channel_count, r_raw_rc_values, PX4IO_RC_INPUT_CHANNELS, &failsafe_state));
+						    &sumd_channel_count, r_raw_rc_values, PX4IO_RC_INPUT_CHANNELS, &sumd_failsafe_state));
 	}
 
 	if (*sumd_updated) {
@@ -153,9 +153,8 @@ bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool 
 
 		r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_SUMD;
 		r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_FRAME_DROP);
-		r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_FAILSAFE);
 
-		if (failsafe_state) {
+		if (sumd_failsafe_state) {
 			r_raw_rc_flags |= PX4IO_P_RAW_RC_FLAGS_FAILSAFE;
 
 		} else {
@@ -165,6 +164,7 @@ bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool 
 
 	/* attempt to parse with SRXL lib */
 	uint8_t srxl_channel_count = 0;
+	bool failsafe_state;
 	hrt_abstime now = hrt_absolute_time();
 
 	*srxl_updated = false;

--- a/src/modules/px4iofirmware/controls.c
+++ b/src/modules/px4iofirmware/controls.c
@@ -135,6 +135,7 @@ bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool 
 	/* get data from FD and attempt to parse with SUMD libs */
 	uint8_t sumd_rssi, sumd_rx_count;
 	uint16_t sumd_channel_count = 0;
+        bool failsafe_state;
 
 	*sumd_updated = false;
 
@@ -142,7 +143,7 @@ bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool 
 		/* set updated flag if one complete packet was parsed */
 		sumd_rssi = RC_INPUT_RSSI_MAX;
 		*sumd_updated |= (OK == sumd_decode(bytes[i], &sumd_rssi, &sumd_rx_count,
-						    &sumd_channel_count, r_raw_rc_values, PX4IO_RC_INPUT_CHANNELS));
+						    &sumd_channel_count, r_raw_rc_values, PX4IO_RC_INPUT_CHANNELS, &failsafe_state));
 	}
 
 	if (*sumd_updated) {
@@ -153,12 +154,18 @@ bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool 
 		r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_SUMD;
 		r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_FRAME_DROP);
 		r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_FAILSAFE);
+
+		if (failsafe_state) {
+			r_raw_rc_flags |= PX4IO_P_RAW_RC_FLAGS_FAILSAFE;
+
+		} else {
+			r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_FAILSAFE);
+		}
 	}
 
 	/* attempt to parse with SRXL lib */
 	uint8_t srxl_channel_count = 0;
 	hrt_abstime now = hrt_absolute_time();
-        bool failsafe_state;
 
 	*srxl_updated = false;
 


### PR DESCRIPTION
This request allows to use GR12/GR24/GR32 graupner receiver with PIXHAWK through the SUMD interface. It corrects issue ArduPilot/ardupilot#5197

It has been tested on PixHawk v2 platform with a GR12L and GR24 receiver.

SUMD decoder has been updated to allow SUMD frames with FailSafe header decoding, and to provide decoded failsafe information.
P4XFMU driver and P4XIO module have been updated to use this failsafe information 
