### PR TITLE
FMUv4: shift DMA channels around

### DIFF
--- a/nuttx-configs/px4fmu-v4/include/board.h
+++ b/nuttx-configs/px4fmu-v4/include/board.h
@@ -274,7 +274,7 @@
   only enable DMA on the sensor bus for now. We don't have enough
   spare DMA channels for the other sensors at the moment
  */
-# define DMACHAN_SPI1_RX DMAMAP_SPI1_RX_2
+# define DMACHAN_SPI1_RX DMAMAP_SPI1_RX_1
 # define DMACHAN_SPI1_TX DMAMAP_SPI1_TX_1
 #endif
 

--- a/nuttx-configs/px4fmu-v4/nsh/defconfig
+++ b/nuttx-configs/px4fmu-v4/nsh/defconfig
@@ -310,8 +310,8 @@ CONFIG_UART4_RXDMA=y
 CONFIG_UART5_RXDMA=y
 # CONFIG_USART6_RS485 is not set
 
-# USART6 DMA conflicts with SPI1_RX2 DMA 
-# CONFIG_USART6_RXDMA is not set
+# USART6 DMA must be enabled for reliable DSM protocol receive
+CONFIG_USART6_RXDMA=y
 # CONFIG_UART7_RS485 is not set
 
 # using UART7_RXDMA with SPI1 DMA causes oops on boot


### PR DESCRIPTION
this re-enables UART6 RXDMA which fixes the problem with DSM RC receive on pixracer
