### PR TITLE
px4fmu: reword fallthrough comments to suppress warnings in newer gcc…

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -658,8 +658,8 @@ PX4FMU::set_mode(Mode mode)
 		up_input_capture_set(2, Rising, 0, NULL, NULL);
 		up_input_capture_set(3, Rising, 0, NULL, NULL);
 		DEVICE_DEBUG("MODE_2PWM2CAP");
-
-	// no break
+		//
+	// fall through
 	case MODE_2PWM:	// v1 multi-port with flow control lines as PWM
 		DEVICE_DEBUG("MODE_2PWM");
 		_pwm_mask = 0x3;
@@ -671,7 +671,7 @@ PX4FMU::set_mode(Mode mode)
 		DEVICE_DEBUG("MODE_3PWM1CAP");
 		up_input_capture_set(3, Rising, 0, NULL, NULL);
 
-	// no break
+	// fall through
 	case MODE_3PWM:	// v1 multi-port with flow control lines as PWM
 		DEVICE_DEBUG("MODE_3PWM");
 


### PR DESCRIPTION
… versions

Part of https://github.com/ArduPilot/ardupilot/pull/7947